### PR TITLE
refactor: use Logger instead of print

### DIFF
--- a/Sources/FusionAuth/TokenManager.swift
+++ b/Sources/FusionAuth/TokenManager.swift
@@ -34,7 +34,7 @@ public class TokenManager {
         do {
             return try JSONDecoder().decode(FusionAuthState.self, from: jsonAuthState.data(using: .utf8)!)
         } catch {
-            print("Error decoding auth state: \(error)")
+            AuthorizationManager.log?.warning("Error decoding auth state: \(error)")
             return nil
         }
     }
@@ -57,7 +57,7 @@ public class TokenManager {
         do {
             storage.set(key: tokenKey, content: try fusionAuthState.toJSON() ?? "")
         } catch {
-            print("Error encoding auth state: \(error)")
+            AuthorizationManager.log?.warning("Error encoding auth state: \(error)")
         }
     }
 

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -252,12 +252,12 @@ extension OAuthAuthorizationService {
                     return
                 }
                 guard let data else {
-                    print("HTTP response data is empty")
+                    AuthorizationManager.log?.warning("HTTP response data is empty")
                     return
                 }
 
                 if response.statusCode != 200 {
-                    print("HTTP: \(response.statusCode), Response: \(String(bytes: data, encoding: .utf8) ?? "")")
+                    AuthorizationManager.log?.warning("HTTP: \(response.statusCode), Response: \(String(bytes: data, encoding: .utf8) ?? "")")
 
                     continuation.resume(throwing: OAuthError.accessTokenNil)
                     return
@@ -267,7 +267,7 @@ extension OAuthAuthorizationService {
                     let userInfo = try JSONDecoder().decode(UserInfo.self, from: data)
                     continuation.resume(returning: userInfo)
                 } catch let jsonError as NSError {
-                    print(jsonError)
+                    AuthorizationManager.log?.warning("JSON decode failed: \(jsonError.localizedDescription)")
                     continuation.resume(throwing: jsonError)
                 }
             }.resume()


### PR DESCRIPTION
Instead of using `print`, use the internal Logger.