### PR TITLE
ci(e2e-test): use fusionauth homebrew repository

### DIFF
--- a/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
@@ -119,7 +119,7 @@ jobs:
 
       # Tap FusionAuth Homebrew formulae.
       - name: Tap FusionAuth Homebrew formulae
-        run: brew tap sonderformat-llc/fusionauth
+        run: brew tap fusionauth/fusionauth
 
       # Install FusionAuth App with brew.
       - name: Install FusionAuth App

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
@@ -148,7 +148,7 @@ jobs:
 
       # Tap FusionAuth Homebrew formulae.
       - name: Tap FusionAuth Homebrew formulae
-        run: brew tap sonderformat-llc/fusionauth
+        run: brew tap fusionauth/fusionauth
 
       # Install FusionAuth App with brew.
       - name: Install FusionAuth App

--- a/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
@@ -115,7 +115,7 @@ jobs:
 
       # Tap FusionAuth Homebrew formulae.
       - name: Tap FusionAuth Homebrew formulae
-        run: brew tap sonderformat-llc/fusionauth
+        run: brew tap fusionauth/fusionauth
 
       # Install FusionAuth App with brew.
       - name: Install FusionAuth App


### PR DESCRIPTION
this is replacing the temporary sonderformat-llc/fusionauth repository with the original fusionauth/fusionauth homebrew repository because of the merge https://github.com/FusionAuth/homebrew-fusionauth/pull/16