### PR TITLE
ci: pin 3rd party actions

### DIFF
--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -43,11 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/swiftlang/swift/releases
-        swift: ["6.0.2"]
+        swift: [ "6.0.2" ]
         # https://developer.apple.com/documentation/xcode-release-notes
-        xcode: ["16.2"]
-        language: [swift]
-        build-mode: [manual]
+        xcode: [ "16.2" ]
+        language: [ swift ]
+        build-mode: [ manual ]
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -37,14 +37,14 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
 
       # Performs analysis using MobSF and outputs a Sarif Report
       - name: Run mobsfscan
-        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353
+        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 #0.4.5
         with:
           args: . --sarif --output mobsf.sarif.json || true
 

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -37,14 +37,14 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
 
       # Performs analysis using MobSF and outputs a Sarif Report
       - name: Run mobsfscan
-        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 #0.4.5
+        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 # 0.4.5
         with:
           args: . --sarif --output mobsf.sarif.json || true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: release
         name: Run prerelease release-please
-        uses: googleapis/release-please-action@v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
         with:
           config-file: ".github/prerelease-config.json"
           manifest-file: ".github/prerelease-manifest.json"
@@ -114,7 +114,7 @@ jobs:
           echo "Running pre-release step!"
 
       - name: Run release release-please
-        uses: googleapis/release-please-action@v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
         with:
           config-file: ".github/release-config.json"
           manifest-file: ".github/release-manifest.json"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: release
         name: Run prerelease release-please
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           config-file: ".github/prerelease-config.json"
           manifest-file: ".github/prerelease-manifest.json"
@@ -114,7 +114,7 @@ jobs:
           echo "Running pre-release step!"
 
       - name: Run release release-please
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           config-file: ".github/release-config.json"
           manifest-file: ".github/release-manifest.json"

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -37,7 +37,7 @@ jobs:
 
       # Performs analysis using Swift Lint and outputs a Sarif Report
       - name: GitHub Action for SwiftLint
-        uses: stanfordbdhg/action-swiftlint@f6ee119765c4b81b667fa84b1e9ee77ca864f622 #v4.1.1
+        uses: stanfordbdhg/action-swiftlint@f6ee119765c4b81b667fa84b1e9ee77ca864f622 # v4.1.1
         with:
           args: --reporter sarif --output lint-results-debug.sarif
           # https://github.com/realm/SwiftLint/issues/4048

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -37,7 +37,7 @@ jobs:
 
       # Performs analysis using Swift Lint and outputs a Sarif Report
       - name: GitHub Action for SwiftLint
-        uses: stanfordbdhg/action-swiftlint@v4.1.1
+        uses: stanfordbdhg/action-swiftlint@f6ee119765c4b81b667fa84b1e9ee77ca864f622 #v4.1.1
         with:
           args: --reporter sarif --output lint-results-debug.sarif
           # https://github.com/realm/SwiftLint/issues/4048


### PR DESCRIPTION
This pull request pins the versions of several 3rd party GitHub Actions used in the repository's workflows. The changes include updates to the `reviewdog`, `MobSF`, `release-please`, and `SwiftLint` actions.

### Affected Actions:

- googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
- maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
- MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 # 0.4.5
- reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
- stanfordbdhg/action-swiftlint@f6ee119765c4b81b667fa84b1e9ee77ca864f622 # v4.1.1
- swift-actions/setup-swift@d4537ff835c9778c934e48f78639e270edd5839e # v2.2.0
