### PR TITLE
fix: Ensure the tenant id is set for well known configuration

### DIFF
--- a/Samples/Quickstart/Quickstart/FusionAuth.plist
+++ b/Samples/Quickstart/Quickstart/FusionAuth.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>tenant</key>
+	<string>d7d09513-a3f5-401c-9685-34ab6c552453</string>
 	<key>storage</key>
 	<string>keychain</string>
 	<key>additionalScopes</key>

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -78,19 +78,19 @@ extension OAuthAuthorizationService {
     /// Fetches the OIDServiceConfiguration from FusionAuth using AppAuth
     private func fetchConfiguration() async throws -> OIDServiceConfiguration {
         try await withCheckedThrowingContinuation { continuation in
-            var issuer: URL?
-            if let baseURL = URL(string: self.fusionAuthUrl) {
-                if let tenantId {
-                    issuer = baseURL.appendingPathComponent(tenantId)
-                } else {
-                    issuer = baseURL
-                }
-            } else {
+            guard let baseURL = URL(string: self.fusionAuthUrl) else {
                 continuation.resume(throwing: OAuthError.invalidIssuer)
                 return
             }
 
-            OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) { configuration, error in
+            let issuer: URL
+            if let tenantId {
+               issuer = baseURL.appendingPathComponent(tenantId)
+            } else {
+               issuer = baseURL
+            }
+
+            OIDAuthorizationService.discoverConfiguration(forIssuer: issuer) { configuration, error in
                 if error != nil {
                     continuation.resume(throwing: error!)
                     return

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -78,7 +78,12 @@ extension OAuthAuthorizationService {
     /// Fetches the OIDServiceConfiguration from FusionAuth using AppAuth
     private func fetchConfiguration() async throws -> OIDServiceConfiguration {
         try await withCheckedThrowingContinuation { continuation in
-            let issuer = URL(string: self.fusionAuthUrl)
+            var issuer = URL(string: self.fusionAuthUrl)
+            
+            if let tenantId {
+                issuer = issuer?.appendingPathComponent(tenantId)
+            }
+                
             OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) { configuration, error in
                 if error != nil {
                     continuation.resume(throwing: error!)

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -94,7 +94,7 @@ extension OAuthAuthorizationService {
                 continuation.resume(throwing: OAuthError.invalidIssuer)
                 return
             }
-            
+
             OIDAuthorizationService.discoverConfiguration(forIssuer: unwrappedIssuer) { configuration, error in
                 if error != nil {
                     continuation.resume(throwing: error!)

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -78,13 +78,24 @@ extension OAuthAuthorizationService {
     /// Fetches the OIDServiceConfiguration from FusionAuth using AppAuth
     private func fetchConfiguration() async throws -> OIDServiceConfiguration {
         try await withCheckedThrowingContinuation { continuation in
-            var issuer = URL(string: self.fusionAuthUrl)
-
-            if let tenantId {
-                issuer = issuer?.appendingPathComponent(tenantId)
+            var issuer: URL?
+            if let baseURL = URL(string: self.fusionAuthUrl) {
+                if let tenantId {
+                    issuer = baseURL.appendingPathComponent(tenantId)
+                } else {
+                    issuer = baseURL
+                }
+            } else {
+                continuation.resume(throwing: OAuthError.invalidIssuer)
+                return
             }
 
-            OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) { configuration, error in
+            guard let unwrappedIssuer = issuer else {
+                continuation.resume(throwing: OAuthError.invalidIssuer)
+                return
+            }
+            
+            OIDAuthorizationService.discoverConfiguration(forIssuer: unwrappedIssuer) { configuration, error in
                 if error != nil {
                     continuation.resume(throwing: error!)
                     return

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -79,11 +79,11 @@ extension OAuthAuthorizationService {
     private func fetchConfiguration() async throws -> OIDServiceConfiguration {
         try await withCheckedThrowingContinuation { continuation in
             var issuer = URL(string: self.fusionAuthUrl)
-            
+
             if let tenantId {
                 issuer = issuer?.appendingPathComponent(tenantId)
             }
-                
+
             OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) { configuration, error in
                 if error != nil {
                     continuation.resume(throwing: error!)

--- a/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
+++ b/Sources/FusionAuth/oauth/OAuthAuthorizationService.swift
@@ -90,12 +90,7 @@ extension OAuthAuthorizationService {
                 return
             }
 
-            guard let unwrappedIssuer = issuer else {
-                continuation.resume(throwing: OAuthError.invalidIssuer)
-                return
-            }
-
-            OIDAuthorizationService.discoverConfiguration(forIssuer: unwrappedIssuer) { configuration, error in
+            OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) { configuration, error in
                 if error != nil {
                     continuation.resume(throwing: error!)
                     return


### PR DESCRIPTION
Insure the tenant id is set so that the well known configuration can be found for the tenant.

Currently, the tenant id is not set so the default tenant is used to find the client_id/application.