### PR TITLE
fix: end to end tests are failing when starting a pre-release

### DIFF
--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -89,7 +89,7 @@ jobs:
 
       # Initialize CodeQL.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.31.10
+        uses: github/codeql-action/init@v4.32.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -119,7 +119,7 @@ jobs:
 
       # Perform CodeQL analysis after the build has completed successfully or failed.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.31.10
+        uses: github/codeql-action/analyze@v4.32.0
         if: success() || failure()
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -26,7 +26,7 @@ jobs:
 
     #runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     #runs-on: [ self-hosted, macos ]
-    runs-on: [ 'macos-15' ]
+    runs-on: [ 'macos-26' ]
 
     #timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     timeout-minutes: 120

--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -46,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/swiftlang/swift/releases
-        swift: [ "6.0.3" ]
+        swift: [ "6.1.0" ]
         # https://developer.apple.com/documentation/xcode-release-notes
-        xcode: [ "16.2" ]
+        xcode: [ "26.0.1" ]
         language: [ swift ]
         build-mode: [ manual ]
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,

--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -46,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/swiftlang/swift/releases
-        swift: [ "6.1.0" ]
+        swift: [ "6.2.0" ]
         # https://developer.apple.com/documentation/xcode-release-notes
-        xcode: [ "26.0.1" ]
+        xcode: [ "26.1.0" ]
         language: [ swift ]
         build-mode: [ manual ]
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,

--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -48,7 +48,7 @@ jobs:
         # https://github.com/swiftlang/swift/releases
         swift: [ "6.2.0" ]
         # https://developer.apple.com/documentation/xcode-release-notes
-        xcode: [ "26.1.0" ]
+        xcode: [ "26.1.1" ]
         language: [ swift ]
         build-mode: [ manual ]
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -91,7 +91,7 @@ jobs:
 
       # Initialize CodeQL.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.31.10
+        uses: github/codeql-action/init@v4.32.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -125,7 +125,7 @@ jobs:
 
       # Perform CodeQL Analysis if the build succeeded or failed.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.31.10
+        uses: github/codeql-action/analyze@v4.32.0
         if: success() || failure()
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -46,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/swiftlang/swift/releases
-        swift: [ "6.1.0" ]
+        swift: [ "6.2.0" ]
         # https://developer.apple.com/documentation/xcode-release-notes
-        xcode: [ "26.0.1" ]
+        xcode: [ "26.1.1" ]
         language: [ swift ]
         build-mode: [ manual ]
         destination:

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -26,7 +26,7 @@ jobs:
 
     #runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     #runs-on: [ self-hosted, macos ]
-    runs-on: [ 'macos-15' ]
+    runs-on: [ 'macos-26' ]
 
     #timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     timeout-minutes: 120

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Connect to FusionAuth App
         run: curl http://localhost:9011/api/status
 
+      - name: List available simulators
+        run: xcrun simctl list runtimes
+
       # Perform the tests from the fusionauth-quickstart-swift-ios-native Sample.
       - name: Perform end to end tests
         run: set -o pipefail && xcodebuild test -workspace FusionAuthSDK.xcworkspace/ -scheme fusionauth-quickstart-swift-ios-native-swift-6 -destination "${{matrix.destination}}" -skipPackagePluginValidation -parallel-testing-enabled NO

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
@@ -41,7 +41,7 @@ jobs:
         simulator-platform: [ "iOS" ]
         simulator-version: [ "26.0.1" ]
         swift: [ "6.1.0" ]
-        os: [ "macos-15" ]
+        os: [ "macos-26" ]
         postgresql-version: [ "16" ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -65,23 +65,6 @@ jobs:
       # Get the Xcode version.
       - name: Get Xcode version
         run: xcodebuild -version
-
-      # Install Xcodes.
-      - name: Install Xcodes
-        if: matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          brew install aria2
-          brew install xcodes
-
-      # Install simulator platform.
-      - name: Install Simulator
-        if: matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          sudo xcodes runtimes
-          sudo xcodes runtimes install '${{ matrix.simulator-platform }} ${{ matrix.simulator-version }}'
-          sudo xcodes runtimes
 
       # Initialize Swift in the matrix specified version.
       - name: Initialize Swift

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
@@ -41,7 +41,7 @@ jobs:
         simulator-platform: [ "iOS" ]
         simulator-version: [ "26.0.1" ]
         swift: [ "6.1.0" ]
-        os: [ "macos-15" ]
+        os: [ "macos-26" ]
         postgresql-version: [ "16" ]
         scheme: [ "fusionauth-quickstart-swift-ios-native-swift-6" ]
         include:

--- a/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
@@ -36,7 +36,7 @@ jobs:
         simulator-platform: [ "iOS" ]
         simulator-version: [ "26.0.1" ]
         swift: [ "6.1.0" ]
-        os: [ "macos-15" ]
+        os: [ "macos-26" ]
         postgresql-version: [ "16" ]
         fusionauth-docker-image-version: [ "1.57.1", "1.58.3", "1.59.1", "1.60.2", "1.61.0" ]
 


### PR DESCRIPTION
End to end tests are failing when starting a pre-release.

The macos-15 GitHub runner has removed support for Xcode 26.0.1. Use the macos-26 GitHub runner in place of macos-15.