### PR TITLE
iOS 26.0.1 removed from macos-26 runner

### DIFF
--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -63,9 +63,6 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
-      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
-        run: sudo xcodebuild -downloadPlatform iOS
-
       # This step removes all other versions of Xcode from the machine.
       - name: Remove old xcode versions
         run: |

--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
+      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        run: sudo xcodebuild -downloadPlatform iOS
+
       # This step removes all other versions of Xcode from the machine.
       - name: Remove old xcode versions
         run: |
@@ -73,14 +76,15 @@ jobs:
           echo "Available Xcode versions after removal:"
           find /Applications -name "Xcode_*" -maxdepth 1 -mindepth 1
 
-      # Initialize Swift in the matrix specified version.
-      - name: Initialize Swift
-        uses: swift-actions/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9 # v3
-        with:
-          swift-version: ${{ matrix.swift }}
+       # Get the Xcode version.
+      - name: Get Xcode version
+        run: xcodebuild -version
+
+      - name: List available simulators
+        run: xcrun simctl list runtimes
 
       # Get the Swift version.
-      - name: Get swift version
+      - name: Get Swift version
         run: swift --version
 
       # Checkout the repository.

--- a/.github/workflows/codeql-package.yml
+++ b/.github/workflows/codeql-package.yml
@@ -45,8 +45,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/swiftlang/swift/releases
-        swift: [ "6.2.0" ]
         # https://developer.apple.com/documentation/xcode-release-notes
         xcode: [ "26.1.1" ]
         language: [ swift ]
@@ -73,7 +71,7 @@ jobs:
           echo "Available Xcode versions after removal:"
           find /Applications -name "Xcode_*" -maxdepth 1 -mindepth 1
 
-       # Get the Xcode version.
+      # Get the Xcode version.
       - name: Get Xcode version
         run: xcodebuild -version
 

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
+      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        run: sudo xcodebuild -downloadPlatform iOS
+
       # Remove any other Xcode version.
       - name: Remove old xcode versions
         run: |
@@ -75,14 +78,15 @@ jobs:
           echo "Available Xcode versions after removal:"
           find /Applications -name "Xcode_*" -maxdepth 1 -mindepth 1
 
-      # Initialize Swift in the matrix specified version.
-      - name: Initialize Swift
-        uses: swift-actions/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9 # v3
-        with:
-          swift-version: ${{ matrix.swift }}
+      # Get the Xcode version.
+      - name: Get Xcode version
+        run: xcodebuild -version
+
+      - name: List available simulators
+        run: xcrun simctl list runtimes
 
       # Get the Swift version.
-      - name: Get swift version
+      - name: Get Swift version
         run: swift --version
 
       # Checkout the repository.

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -45,8 +45,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/swiftlang/swift/releases
-        swift: [ "6.2.0" ]
         # https://developer.apple.com/documentation/xcode-release-notes
         xcode: [ "26.1.1" ]
         language: [ swift ]
@@ -116,9 +114,6 @@ jobs:
         run: |
           sleep 10
           df -h
-
-      - name: List available simulators
-        run: xcodebuild -showdestinations -scheme fusionauth-quickstart-swift-ios-native-swift-6
 
       # Perform the build manually.
       - name: Manual Build

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -52,7 +52,7 @@ jobs:
         language: [ swift ]
         build-mode: [ manual ]
         destination:
-          - "platform=iOS Simulator,OS=26.1.1,name=iPhone 17"
+          - "platform=iOS Simulator,OS=26.1,name=iPhone 17"
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -65,9 +65,6 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
-      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
-        run: sudo xcodebuild -downloadPlatform iOS
-
       # Remove any other Xcode version.
       - name: Remove old xcode versions
         run: |

--- a/.github/workflows/codeql-samples-quickstart.yml
+++ b/.github/workflows/codeql-samples-quickstart.yml
@@ -52,7 +52,7 @@ jobs:
         language: [ swift ]
         build-mode: [ manual ]
         destination:
-          - "platform=iOS Simulator,OS=26.0.1,name=iPhone 17"
+          - "platform=iOS Simulator,OS=26.1.1,name=iPhone 17"
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-latest.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
+      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        run: sudo xcodebuild -downloadPlatform iOS
+
       # Remove any other Xcode version.
       - name: Remove old xcode versions
         run: |
@@ -64,6 +67,9 @@ jobs:
       # Get the Xcode version.
       - name: Get Xcode version
         run: xcodebuild -version
+
+      - name: List available simulators
+        run: xcrun simctl list runtimes
 
       # Get the Swift version.
       - name: Get Swift version
@@ -157,9 +163,6 @@ jobs:
       # Connect to FusionAuth App.
       - name: Connect to FusionAuth App
         run: curl http://localhost:9011/api/status
-
-      - name: List available simulators
-        run: xcrun simctl list runtimes
 
       # Perform the tests from the fusionauth-quickstart-swift-ios-native Sample.
       - name: Perform end to end tests

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
+      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        run: sudo xcodebuild -downloadPlatform iOS
+        
       # Remove any other Xcode version.
       - name: Remove old xcode versions
         run: |
@@ -81,23 +84,9 @@ jobs:
       - name: Get Xcode version
         run: xcodebuild -version
 
-      # Install Xcodes.
-      - name: Install Xcodes
-        if: matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          brew install aria2
-          brew install xcodes
-
-      # Install simulator platform.
-      - name: Install Simulator
-        if: matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          sudo xcodes runtimes
-          sudo xcodes runtimes install '${{ matrix.simulator-platform }} ${{ matrix.simulator-version }}'
-          sudo xcodes runtimes
-
+      - name: List available simulators
+        run: xcrun simctl list runtimes
+        
       # Get the Swift version.
       - name: Get Swift version
         run: swift --version

--- a/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-ios-matrix.yml
@@ -68,6 +68,8 @@ jobs:
           xcode-version: ${{ matrix.xcode }}
 
       - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        if: matrix.os == 'macos-26'
+        shell: bash
         run: sudo xcodebuild -downloadPlatform iOS
         
       # Remove any other Xcode version.
@@ -86,7 +88,7 @@ jobs:
 
       - name: List available simulators
         run: xcrun simctl list runtimes
-        
+
       # Get the Swift version.
       - name: Get Swift version
         run: swift --version

--- a/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
+      - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        run: sudo xcodebuild -downloadPlatform iOS
+
       # Remove any other Xcode version.
       - name: Remove old xcode versions
         run: |
@@ -61,22 +64,8 @@ jobs:
       - name: Get Xcode version
         run: xcodebuild -version
 
-      # Install Xcodes.
-      - name: Install Xcodes
-        if: matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          brew install aria2
-          brew install xcodes
-
-      # Install simulator platform.
-      - name: Install Simulator
-        if: matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          sudo xcodes runtimes
-          sudo xcodes runtimes install '${{ matrix.simulator-platform }} ${{ matrix.simulator-version }}'
-          sudo xcodes runtimes
+      - name: List available simulators
+        run: xcrun simctl list runtimes
 
       # Get the Swift version.
       - name: Get Swift version

--- a/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-ios-latest.yml
@@ -48,6 +48,8 @@ jobs:
           xcode-version: ${{ matrix.xcode }}
 
       - name: Install iOS 26.0.1 Platform which was removed from the runner in https://github.com/actions/runner-images/pull/13875
+        if: matrix.os == 'macos-26'
+        shell: bash
         run: sudo xcodebuild -downloadPlatform iOS
 
       # Remove any other Xcode version.


### PR DESCRIPTION
Install iOS 26.0.1 Platform which was removed from the macos-26 runner in [PR](https://github.com/actions/runner-images/pull/13875)

I'm going to create an issue to upgrade to the iOS, 26.4


[Copilot Review](https://github.com/FusionAuth/fusionauth-swift-sdk/pull/150#pullrequestreview-4102179346)